### PR TITLE
Add Cumberland Building Society

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -4348,6 +4348,17 @@
       }
     },
     {
+      "displayName": "Cumberland Building Society",
+      "locationSet": {"include": ["gb"]},
+      "tags": {
+        "amenity": "bank",
+        "brand": "Cumberland Building Society",
+        "brand:wikidata": "Q5193845",
+        "brand:wikipedia": "en:Cumberland Building Society",
+        "name": "Cumberland Building Society"
+      }    
+    },
+    {
       "displayName": "Danske Bank",
       "id": "danskebank-c75d31",
       "locationSet": {


### PR DESCRIPTION
Add Cumberland Building Society (Bank) operating mostly in the North West of England.